### PR TITLE
Handle too many request in rest api

### DIFF
--- a/;
+++ b/;
@@ -1,0 +1,9 @@
+Handle too many request in rest api
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch feature/handle-too-many-request
+# Changes to be committed:
+#	modified:   config/settings.py
+#	new file:   pytest.ini
+#

--- a/config/settings.py
+++ b/config/settings.py
@@ -297,6 +297,12 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
     ),
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '50/min',
+    }
 }
 
 # Set max page limit to 50 in open api

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+log_cli = true
+python_files = tests.py test_*.py *_tests.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = config.settings
-log_cli = true
-python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
## Changes
- Added throttling for handling too many request in rest api

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
