### PR TITLE
Removed data fetching from CountryEmergencyProfile

### DIFF
--- a/apps/visualization/filters.py
+++ b/apps/visualization/filters.py
@@ -18,6 +18,7 @@ from .models import (
     DataGranular,
     ContextualData,
     EpiDataGlobal,
+    Sources,
     GlobalLevel,
     Countries,
     Narratives,

--- a/apps/visualization/schema.py
+++ b/apps/visualization/schema.py
@@ -147,9 +147,10 @@ class Query:
         self,
         iso3: Optional[str] = None,
         emergency: Optional[str] = None,
+        context_indicator_id: Optional[str] = None,
     ) -> List[ContextualDataWithMultipleEmergencyType]:
         return await get_contextual_data_with_multiple_emergency(
-            iso3, emergency
+            iso3, emergency, context_indicator_id
         )
 
     @strawberry.field


### PR DESCRIPTION
## Changes
- Fetched data for overview table, overview map and top bottom 5 from DataCountryLevelMostRecent table only.
- Removed hard coded context_indicator_id "total_cases" from ContextualDataWithMultipleEmmergency query
- Removed hard coded context_indicator_id "new_cases_per_million" from overview table, overview map


## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
