### PR TITLE
Added a button cache clear in admin panel

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -133,7 +133,7 @@ ROOT_URLCONF = 'config.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, "templates")],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/config/urls.py
+++ b/config/urls.py
@@ -24,6 +24,7 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view as swagger_get_schema_view
 
 from apps.visualization import views
+from utils import cache_clear
 
 router = routers.DefaultRouter()
 
@@ -44,6 +45,8 @@ urlpatterns = [
     # rest api urls
     path('api/v1/', schema_view.with_ui('swagger', cache_timeout=0), name="swagger-schema"),
     path('api/v1/context_indicators/', views.ContextIndicatorsViews.as_view()),
+
+    path('clear-cache/', cache_clear, name='clear_cache')
 ]
 
 admin.site.site_header = "RCCE Collective Services Administration"

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,12 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+
+{% block userlinks %}
+    <a href="{% url 'clear_cache' %}">Clear cache</a> /
+    {{ block.super }}
+{% endblock userlinks %}

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,9 @@
 import hashlib
 from django.core.cache import cache
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.contrib import messages
+from django.utils.safestring import mark_safe
 from strawberry import UNSET
 from dataclasses import asdict
 
@@ -56,3 +60,9 @@ def clean_filters(filters):
         for k, v in filters.items()
         if v is not None
     }
+
+
+def cache_clear(request):
+    cache.clear()
+    messages.add_message(request, messages.INFO, mark_safe("Cache Cleared"))
+    return HttpResponseRedirect(reverse('admin:index'))


### PR DESCRIPTION
## Changes
- Added button cache clear in adminsite

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
