### PR TITLE
Add type in indicator list

### DIFF
--- a/apps/visualization/types.py
+++ b/apps/visualization/types.py
@@ -546,12 +546,14 @@ class DisaggregationType:
 class CountryIndicatorType:
     indicator_id: Optional[str]
     indicator_description: Optional[str]
+    type: Optional[str]
 
 
 @strawberry.type
 class OverviewIndicatorType:
     indicator_id: Optional[str]
     indicator_description: Optional[str]
+    type: Optional[str]
 
 
 @strawberry.type
@@ -568,8 +570,8 @@ class FilterOptionsType:
     async def country_indicators(
         self,
         iso3: str,
-        type: Optional[str] = None,
         outbreak: Optional[str] = None,
+        type: Optional[str] = None,
     ) -> List[CountryIndicatorType]:
         return await get_country_indicators(iso3, outbreak, type)
 
@@ -586,9 +588,10 @@ class FilterOptionsType:
         self,
         out_break: Optional[str] = None,
         region: Optional[str] = None,
+        type: Optional[str] = None,
     ) -> List[OverviewIndicatorType]:
 
-        return await get_overview_indicators(out_break, region)
+        return await get_overview_indicators(out_break, region, type)
 
     @strawberry.field
     async def types(self) -> List[str]:

--- a/apps/visualization/utils.py
+++ b/apps/visualization/utils.py
@@ -117,8 +117,9 @@ def get_country_indicators(iso3, outbreak, type):
         CountryIndicatorType(
             indicator_id=indicator['indicator_id'],
             indicator_description=indicator['indicator_description'],
+            type=indicator['type'],
         ) for indicator in indicators.distinct().values(
-            'indicator_id', 'indicator_description'
+            'indicator_id', 'indicator_description', 'type',
         ).order_by('indicator_description')
     ]
 
@@ -161,12 +162,13 @@ def get_topics(thematic):
 
 
 @sync_to_async
-def get_overview_indicators(out_break, region):
+def get_overview_indicators(out_break, region, type):
     from .types import OverviewIndicatorType
 
     filters = clean_filters({
         'emergency': out_break,
-        'region': region
+        'region': region,
+        'type': type,
     })
 
     options = list(
@@ -177,13 +179,15 @@ def get_overview_indicators(out_break, region):
         ).values_list(
             'indicator_id',
             'indicator_description',
+            'type',
         ).distinct().order_by('indicator_description')
     )
     return [
         OverviewIndicatorType(
             indicator_id=name,
             indicator_description=description,
-        ) for name, description in options
+            type=type,
+        ) for name, description, type in options
     ]
 
 


### PR DESCRIPTION
##Changes
- Add type in indicator list in Filter Options

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
