### PR TITLE
Add indicator_month in overview map query response

### DIFF
--- a/apps/visualization/types.py
+++ b/apps/visualization/types.py
@@ -631,6 +631,7 @@ class OverviewMapType:
     iso3: str
     format: str
     emergency: str
+    indicator_month: str
 
     @strawberry.field
     def country_id(self) -> ID:

--- a/apps/visualization/utils.py
+++ b/apps/visualization/utils.py
@@ -276,6 +276,7 @@ def get_overview_map_data(
             indicator_value=item['indicator_value'],
             format=item['format'],
             emergency=item['emergency'],
+            indicator_month=item['indicator_month']
         ) for item in qs
     ]
 


### PR DESCRIPTION
## Changes

- Add indicator_month in overview map query response


- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
