### PR TITLE
Fix context_indicator external api

### DIFF
--- a/apps/visualization/schema.py
+++ b/apps/visualization/schema.py
@@ -292,7 +292,7 @@ class Query:
         indicator_id: Optional[str] = None,
         emergency: Optional[str] = None,
     ) -> List[SubvariableType]:
-        return  await get_region_level_subvariables(region, indicator_id, emergency)
+        return await get_region_level_subvariables(region, indicator_id, emergency)
 
     @strawberry.field
     async def global_level_subvariables(

--- a/apps/visualization/views.py
+++ b/apps/visualization/views.py
@@ -46,7 +46,7 @@ class ContextIndicatorsViews(ListAPIView):
                 raise ValidationError(
                     {'error': f'Limit must be less or equal to {settings.OPEN_API_MAX_PAGE_LIMIT}'}
                 )
-        result = DataCountryLevelMostRecent.filter(category='Global').objects.order_by(
+        result = DataCountryLevelMostRecent.objects.filter(category='Global').order_by(
             '-indicator_month'
         ).values(
             'subvariable'


### PR DESCRIPTION
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
